### PR TITLE
Add in floe-size-dependent attenuation scheme (case 8)

### DIFF
--- a/src/cpl_nuopc/wav_comp_nuopc.F90
+++ b/src/cpl_nuopc/wav_comp_nuopc.F90
@@ -562,7 +562,16 @@ contains
     inflags1(1:5) = .true.
     !      flags(1:4) = .true.   !changed by Adrean (lev,curr,wind,ice on)
     !      flags(3:4) = .true.   !changed by Adrean (wind,ice on)
-    inflags2(4) = .true. ! LR
+
+    ! LR - I don't understand the difference between inflags1 and inflags2
+    ! I am setting them both here to get thickness and floe size import to waves
+    ! and to turn on attenuation
+    inflags1(-7) = .true. ! LR thickness 
+    inflags1(-3) = .true. ! LR floe size 
+    inflags2(-7) = .true. ! LR thickness
+    inflags2(-3) = .true. ! LR floe size
+
+    inflags2(4) = .true.  ! LR
     !--------------------------------------------------------------------
     ! Set time frame
     !--------------------------------------------------------------------

--- a/src/cpl_nuopc/wav_comp_nuopc.F90
+++ b/src/cpl_nuopc/wav_comp_nuopc.F90
@@ -155,7 +155,7 @@ module wav_comp_nuopc
   use w3wdatmd              , only: time, w3ndat, w3dimw, w3setw
   use w3adatmd
   !HK flags is now inflags1
-  use w3idatmd              , only: inflags1, w3seti, w3ninp
+  use w3idatmd              , only: inflags1, inflags2, w3seti, w3ninp
   use w3idatmd              , only: TC0, CX0, CY0, TCN, CXN, CYN !HK, NX, NY
   use w3idatmd              , only: TW0, WX0, WY0, DT0, TWN, WXN, WYN, DTN
   use w3idatmd              , only: TIN, ICEI, TLN, WLEV, HML
@@ -562,7 +562,7 @@ contains
     inflags1(1:5) = .true.
     !      flags(1:4) = .true.   !changed by Adrean (lev,curr,wind,ice on)
     !      flags(3:4) = .true.   !changed by Adrean (wind,ice on)
-
+    inflags2(4) = .true. ! LR
     !--------------------------------------------------------------------
     ! Set time frame
     !--------------------------------------------------------------------
@@ -932,10 +932,10 @@ contains
 
     ! gx17
    !180.0000       180.0000       180.0000       15.00000 
-    dtmax  = 180.0000 
-    dtcfl  = 180.0000
-    dtcfli = 180.0000
-    dtmin  = 15.00000
+    dtmax  = 1800.0000 ! LR 
+    dtcfl  = 600.0000
+    dtcfli = 1800.0000
+    dtmin  = 1800.00000
 
     call mpi_barrier ( mpi_comm, ierr )
 

--- a/src/source/w3gdatmd.F90
+++ b/src/source/w3gdatmd.F90
@@ -1691,7 +1691,6 @@
       BTBETA => GRIDS(IMOD)%BTBETA
 !
 
-print*, 'HK w3gdatmd: dtmax, dtcfl, dtcfli, dtmin', dtmax, dtcfl, dtcfli, dtmin 
       GINIT  => GRIDS(IMOD)%GINIT
       GUGINIT  => GRIDS(IMOD)%GUGINIT
       FLDRY  => GRIDS(IMOD)%FLDRY

--- a/src/source/w3iogomd.F90
+++ b/src/source/w3iogomd.F90
@@ -1954,6 +1954,23 @@ print*, 'HK::ALERT inside W3FLGRDFLAG'
                   SWW = ATAN2(USSY(JSEA),USSX(JSEA)) - UD(JSEA)
                   ! ALPHALS: angle between wind and LC direction, Surface
                   ! Stokes drift
+                  ! LR check for divide by zero
+                  if ((LANGMT(JSEA)**2  &
+                    /0.4*LOG(MAX(ABS(HML(IX,IY)/4./HS(JSEA)),1.0))+COS(SWW)).eq.0.) then
+                      print *, 'LR warning A denom 0.'
+                      ! This appears to be a decimal precision error
+                      ! The first term equals minus the second term to 6 decimal places
+                      ! The denominator should be a very small number (e-7)
+                      ! ATAN(sin(sww)/small number) tends to pi/2 
+                      ! So I hardcoded this here.
+                      ALPHALS(JSEA) = -1.5707956594501575
+                  else
+
+                      ALPHALS(JSEA) = ATAN(SIN(SWW) / (LANGMT(JSEA)**2  &
+                    /0.4*LOG(MAX(ABS(HML(IX,IY)/4./HS(JSEA)),1.0))+COS(SWW)))
+                  end if
+ 
+
                   ALPHALS(JSEA) = ATAN( SIN(SWW) / ( LANGMT(JSEA)**2  &
                     /0.4*LOG(MAX(ABS(HML(IX,IY)/4./HS(JSEA)),1.0))+COS(SWW)))
                   LAPROJ(JSEA) = LANGMT(JSEA) &
@@ -1963,15 +1980,10 @@ print*, 'HK::ALERT inside W3FLGRDFLAG'
                   SWW = ATAN2(USSYH(JSEA),USSXH(JSEA)) - UD(JSEA)
                   ! ALPHAL: angle between wind and LC direction
                   
-                  ! LR check for divide by zero
+                  ! LR check for divide by zero (same as above)
                   if ((LANGMT(JSEA)**2  &
                     /0.4*LOG(MAX(ABS(HML(IX,IY)/4./HS(JSEA)),1.0))+COS(SWW)).eq.0.) then
-                      print *, 'LR warning denom 0.'
-                      ! This appears to be a decimal precision error
-                      ! The first term in equals minus the second term to 6 decimal places
-                      ! The denominator should be a very small number (e-7)
-                      ! ATAN(sin(sww)/small number) tends to pi/2 
-                      ! So I hardcoded this here.
+                      print *, 'LR warning B denom 0.'
                       ALPHAL(JSEA) = -1.5707956594501575
                   else
 

--- a/src/source/w3iogomd.F90
+++ b/src/source/w3iogomd.F90
@@ -1962,8 +1962,22 @@ print*, 'HK::ALERT inside W3FLGRDFLAG'
                   ! Stokes depth
                   SWW = ATAN2(USSYH(JSEA),USSXH(JSEA)) - UD(JSEA)
                   ! ALPHAL: angle between wind and LC direction
-                  ALPHAL(JSEA) = ATAN(SIN(SWW) / (LANGMT(JSEA)**2  &
+                  
+                  ! LR check for divide by zero
+                  if ((LANGMT(JSEA)**2  &
+                    /0.4*LOG(MAX(ABS(HML(IX,IY)/4./HS(JSEA)),1.0))+COS(SWW)).eq.0.) then
+                      print *, 'LR warning denom 0.'
+                      ! This appears to be a decimal precision error
+                      ! The first term in equals minus the second term to 6 decimal places
+                      ! The denominator should be a very small number (e-7)
+                      ! ATAN(sin(sww)/small number) tends to pi/2 
+                      ! So I hardcoded this here.
+                      ALPHAL(JSEA) = -1.5707956594501575
+                  else
+
+                      ALPHAL(JSEA) = ATAN(SIN(SWW) / (LANGMT(JSEA)**2  &
                     /0.4*LOG(MAX(ABS(HML(IX,IY)/4./HS(JSEA)),1.0))+COS(SWW)))
+                  end if
                   LASL(JSEA) = SQRT(UST(JSEA)*ASF(JSEA)         &
                        * SQRT(DAIR/DWAT)                       &
                        / SQRT(USSXH(JSEA)**2+USSYH(JSEA)**2))

--- a/src/source/w3sic4md.F90
+++ b/src/source/w3sic4md.F90
@@ -377,7 +377,6 @@
 ! 1.  Make calculations ---------------------------------------------- /
 !
 ! 1.a Calculate WN_I
-print*, 'HK IC4METHOD', IC4METHOD 
       SELECT CASE (IC4METHOD)
  
         CASE (1) ! IC4M1 : Exponential fit to Wadhams et al. 1988

--- a/src/source/w3sic4md.F90
+++ b/src/source/w3sic4md.F90
@@ -350,14 +350,16 @@
 !   We cannot remove the other use of INFLAGS below,
 !   because we would get 'array not allocated' error for the methods
 !   that don't use MUDV, etc. and don't have MUDV allocated.
- 
+
+
+
       IF (INFLAGS2(-7)) ICECOEF1 = ICEP1(IX,IY) ! a.k.a. IC1
       IF (INFLAGS2(-6)) ICECOEF2 = ICEP2(IX,IY) ! etc.
       IF (INFLAGS2(-5)) ICECOEF3 = ICEP3(IX,IY)
       IF (INFLAGS2(-4)) ICECOEF4 = ICEP4(IX,IY)
       IF (INFLAGS2(-3)) ICECOEF5 = ICEP5(IX,IY)
       IF (INFLAGS2(4))  iceconc  = ICEI(IX,IY)    ! CMB 
-
+ 
 ! Borrow from Smud (error if BT8 or BT9)
       IF (INFLAGS2(-2)) ICECOEF6 = MUDD(IX,IY) ! a.k.a. MDN
       IF (INFLAGS2(-1)) ICECOEF7 = MUDT(IX,IY) ! a.k.a. MTH

--- a/src/source/w3sic4md.F90
+++ b/src/source/w3sic4md.F90
@@ -277,7 +277,7 @@
       USE W3SERVMD, ONLY: EXTCDE
       USE W3GDATMD, ONLY: NK, NTH, NSPEC, SIG, MAPWN, IC4PARS, DDEN, &
                           IC4_KI, IC4_FC, NIC4
-      USE W3IDATMD, ONLY: ICEP1, ICEP2, ICEP3, ICEP4, ICEP5, &
+      USE W3IDATMD, ONLY: ICEP1, ICEP2, ICEP3, ICEP4, ICEP5, ICEI, & ! CMB
                           MUDT, MUDV, MUDD, INFLAGS2
  
 !
@@ -297,6 +297,8 @@
       REAL                    :: ICECOEF1, ICECOEF2, ICECOEF3, &
                                  ICECOEF4, ICECOEF5, ICECOEF6, &
                                  ICECOEF7, ICECOEF8
+      REAL                    :: x1,x2,x3,x1sqr,x2sqr,x3sqr, &
+                                 perfour,amhb,bmhb,iceconc ! CMB
       REAL                    :: KI1,KI2,KI3,KI4,FC5,FC6,FC7,FREQ
       REAL                    :: HS, EMEAN, HICE
       REAL, ALLOCATABLE       :: WN_I(:)  ! exponential decay rate for amplitude
@@ -325,6 +327,7 @@
       KARG2    = 0.0
       KARG3    = 0.0
       WN_I     = 0.0
+      iceconc  = 0.0 ! CMB
       ALPHA    = 0.0
       ICECOEF1 = 0.0
       ICECOEF2 = 0.0
@@ -353,13 +356,15 @@
       IF (INFLAGS2(-5)) ICECOEF3 = ICEP3(IX,IY)
       IF (INFLAGS2(-4)) ICECOEF4 = ICEP4(IX,IY)
       IF (INFLAGS2(-3)) ICECOEF5 = ICEP5(IX,IY)
- 
+      IF (INFLAGS2(4))  iceconc  = ICEI(IX,IY)    ! CMB 
+
 ! Borrow from Smud (error if BT8 or BT9)
       IF (INFLAGS2(-2)) ICECOEF6 = MUDD(IX,IY) ! a.k.a. MDN
       IF (INFLAGS2(-1)) ICECOEF7 = MUDT(IX,IY) ! a.k.a. MTH
       IF (INFLAGS2(0 )) ICECOEF8 = MUDV(IX,IY) ! a.k.a. MVS
  
       IC4METHOD = IC4PARS(1)
+      IC4METHOD = 8 ! LR I don't know where to do this properly
 !
 ! x.  No ice --------------------------------------------------------- /
 !
@@ -479,6 +484,49 @@
            END DO
            WN_I= 0.5 * ALPHA
  
+        CASE (8) !CMB added option of cubic fit to Meylan, Horvat & Bitz in prep
+	   ! ICECOEF1 is thickness 
+	   ! ICECOEF5 is floe size 
+           ! TPI/SIG is period
+	   x3=min(ICECOEF1,3.5)        ! limit thickness to 3.5 m
+	   x3=max(x3,0.1)        ! limit thickness >0.1 m since I make fit below
+           x2=min(ICECOEF5*0.5,100.0)  ! convert dia to radius, limit to 100m
+           x2=max(2.5,x2)
+	   x2sqr=x2*x2
+	   x3sqr=x3*x3
+!           write(*,*) 'floe size', x2
+!           write(*,*) 'sic',iceconc
+	   amhb = 2.12e-3
+	   bmhb = 4.59e-2
+
+	   DO IK=1, NK
+              x1=TPI/SIG(IK)   ! period
+	      x1sqr=x1*x1
+              KARG1(ik)=-0.26982 + 1.5043*x3 - 0.70112*x3sqr + 0.011037*x2 +  &
+                 -0.0073178*x2*x3 + 0.00036604*x2*x3sqr + &
+                 -0.00045789*x2sqr + 1.8034e-05*x2sqr*x3 + &
+                 -0.7246*x1 + 0.12068*x1*x3 + &
+                 -0.0051311*x1*x3sqr + 0.0059241*x1*x2 + &
+                  0.00010771*x1*x2*x3 - 1.0171e-05*x1*x2sqr + &
+                  0.0035412*x1sqr - 0.0031893*x1sqr*x3 + &
+                 -0.00010791*x1sqr*x2 + &
+                  0.00031073*x1**3 + 1.5996e-06*x2**3 + 0.090994*x3**3 
+       	      KARG1(ik)=min(karg1(ik),0.0)
+              WN_I(ik)  = 10.0**KARG1(ik)
+!	      if (WN_I(ik).gt.0.9) then
+!	        write(*,*) 'whacky',WN_I(ik),x1,x2,x3
+!              endif 
+	      perfour=x1sqr*x1sqr
+	      if ((x1.gt.5.0) .and. (x1.lt.20.0)) then
+	        WN_I(IK) = WN_I(IK) + amhb/x1sqr+bmhb/perfour
+	      else if (x1.gt.20.0) then
+	        WN_I(IK) = amhb/x1sqr+bmhb/perfour
+	      endif 
+	   enddo
+!           write(*,*) 'Attena',(10.0**KARG1(IK),IK=1,5)
+!           write(*,*) 'Attenb',(WN_I(IK),IK=1,5)
+
+
         CASE DEFAULT
           WN_I = ICECOEF1 !Default to IC1: Uniform in k
  

--- a/src/source/w3updtmd.F90
+++ b/src/source/w3updtmd.F90
@@ -984,7 +984,8 @@
       TIC5(2) = TI5(2)
  
 ! 2.  Main loop over sea points -------------------------------------- *
- 
+
+      print *, 'LR FLFLOE ',FLFLOE 
       DO ISEA=1, NSEA
 !
         IX        = MAPSF(ISEA,1)


### PR DESCRIPTION
### Description of changes:

Add in case 8 for floe size dependent attenuation
Not sure where the right place to set IC4PARS is, so at the moment ICMETHOD=8 is hard-coded
The diamforww and thickforww are not yet being passed through the coupler to the wave model

